### PR TITLE
Missing comma in code

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -379,7 +379,7 @@ define logrotate::rule(
   require logrotate
 
   $real_ensure = $logrotate::bool_absent ? {
-    true  => 'absent'
+    true  => 'absent',
     false => $ensure,
   }
 


### PR DESCRIPTION
Hello,

Puppet can not compile the manifest without this missing ,.
