### PR TITLE
switch to new variables @ format

### DIFF
--- a/templates/conf.erb
+++ b/templates/conf.erb
@@ -1,19 +1,19 @@
 # File Managed by Puppet
 
-<% log.each do |lo| -%>
+<% @log.each do |lo| -%>
 <%= lo %>
 <% end -%>{
-<% options.each do |opt| -%>
+<% @options.each do |opt| -%>
 	<%= opt %>
 <% end -%>
-<% if prerotate != "NONE" -%>
+<% if @prerotate != "NONE" -%>
 	prerotate 
-		<%= prerotate %> 
+		<%= @prerotate %> 
 	endscript
 <% end -%>
-<% if postrotate != "NONE" -%>
+<% if @postrotate != "NONE" -%>
 	postrotate 
-		<%= postrotate %> 
+		<%= @postrotate %> 
 	endscript 
 <% end -%>
 }


### PR DESCRIPTION
This is to remove warnings:

```
Warning: Config file /etc/puppet/hiera.yaml not found, using Hiera defaults
Warning: Variable access via 'log' is deprecated. Use '@log' instead. template[/tmp/vagrant-puppet-1/modules-0/logrotate/templates/conf.erb]:3
   (at /tmp/vagrant-puppet-1/modules-0/logrotate/templates/conf.erb:3:in `block in result')
Warning: Variable access via 'options' is deprecated. Use '@options' instead. template[/tmp/vagrant-puppet-1/modules-0/logrotate/templates/conf.erb]:6
   (at /tmp/vagrant-puppet-1/modules-0/logrotate/templates/conf.erb:6:in `block in result')
Warning: Variable access via 'prerotate' is deprecated. Use '@prerotate' instead. template[/tmp/vagrant-puppet-1/modules-0/logrotate/templates/conf.erb]:9
   (at /tmp/vagrant-puppet-1/modules-0/logrotate/templates/conf.erb:9:in `block in result')
Warning: Variable access via 'postrotate' is deprecated. Use '@postrotate' instead. template[/tmp/vagrant-puppet-1/modules-0/logrotate/templates/conf.erb]:14
   (at /tmp/vagrant-puppet-1/modules-0/logrotate/templates/conf.erb:14:in `block in result')
```
