### PR TITLE
switch from require to include to break the dependency cycle

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -28,7 +28,7 @@ define logrotate::file (
   $content = '' ,
   $ensure  = present ) {
 
-  require logrotate
+  include logrotate
 
   $manage_file_source = $source ? {
     ''        => undef,


### PR DESCRIPTION
the last commit introduced a dependency cycle

switched to just include the parent class as the file resource already declares its dependency's
require => Package['logrotate']
