### PR TITLE
puppet >= 3.8 compatibility fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,7 +169,7 @@ class logrotate (
   }
 
   # The whole logrotate configuration directory can be recursively overriden
-  if $logrotate::source_dir {
+  if $logrotate::source_dir != '' {
     file { 'logrotate.dir':
       ensure  => directory,
       path    => $logrotate::config_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,7 +50,7 @@ class logrotate::params {
   $version = 'present'
   $absent = false
   $audit_only = false
-  $noops = undef
+  $noops = false
   $files = {}
 
 }


### PR DESCRIPTION
See below for the changes that make the module work with default settings under puppet >= 3.8. A similar update has been submitted for zabbix_agent module, too.