### PR TITLE
Noop param default changed to false

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,7 +50,7 @@ class logrotate::params {
   $version = 'present'
   $absent = false
   $audit_only = false
-  $noops = undef
+  $noops = false
   $files = {}
 
 }


### PR DESCRIPTION
Fixed error on future parser
> Error: Failed to apply catalog: Parameter noop failed on Package[logrotate]: Invalid value "". Valid values are true, false.  at /etc/puppet/environments/production/modules/logrotate/manifests/init.pp:146